### PR TITLE
Configure Resynchronisation duration through deployment file

### DIFF
--- a/deploy/atlas-db.yaml
+++ b/deploy/atlas-db.yaml
@@ -61,3 +61,5 @@ spec:
       - name: atlas-db-controller
         image: infoblox/atlas-db:latest
         imagePullPolicy: Always
+        args:
+          - "-resync=3m"


### PR DESCRIPTION
Configure the resync duration through deployment file. The default value is 5 minutes. Here it is changed to 3 minutes.  The default value is defined in main.go file. 