### PR TITLE
Modify custom resource definition

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -30,15 +30,6 @@ spec:
     kind: Database
     plural: databases
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-            - serverType
-          properties:
-            serverType:
-              type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
  - remove validation check for `serverType` from databases crd.
    With this `serverType` will not be a mandated field while creating
    database resources.