### PR TITLE
Add support for CustomSubResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ resource will use the administrative `Secret` created by the `Database` resource
 and maintain a specific version of the database schema.
 
 ## Prerequisite
-   - Kubernetes cluster version should be > 1.9
+   - Kubernetes cluster version should be >= 1.10
+   - `CustomResourceSubresources` must be enabled. This can be done by passing `--feature-gates=CustomResourceSubresources=true` while starting kubernetes cluster.
    - Migration/Initialization scripts should follow [this](https://github.com/golang-migrate/migrate/blob/master/MIGRATIONS.md)
    - GitHub is the only supported source for Migration scripts.
    - To access gitHub source need user's **personal access tokens**

--- a/atlas-db-controller/controller.go
+++ b/atlas-db-controller/controller.go
@@ -42,12 +42,7 @@ const (
 	// to sync due to a resource it should own already existing
 	ErrResourceExists = "ErrResourceExists"
 
-	MessageServiceExists  = "Service %q already exists and is not managed by DatabaseServer"
-	MessageSecretExists   = "Secret %q already exists and is not managed by DatabaseServer"
-	MessagePodExists      = "Pod %q already exists and is not managed by DatabaseServer"
-	MessageServerSynced   = "DatabaseServer synced successfully"
-	MessageDatabaseSynced = "Database synced successfully"
-	MessageSchemaSynced   = "DatabaseSchema synced successfully"
+	MessageSecretExists = "Secret %q already exists and is not managed by DatabaseServer"
 
 	StateCreating = "Creating"
 	StateDeleting = "Deleting"

--- a/atlas-db-controller/databaseResource.go
+++ b/atlas-db-controller/databaseResource.go
@@ -17,6 +17,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	MessageDatabaseSynced = "Database synced successfully"
+)
+
 func (c *Controller) enqueueDatabase(obj interface{}) {
 	var object metav1.Object
 	var ok bool
@@ -233,14 +237,15 @@ func (c *Controller) getHostAndPort(dsn string) (host string, port int32) {
 }
 
 func (c *Controller) updateDatabaseStatus(key string, db *atlas.Database, state, msg string) (*atlas.Database, error) {
+	// NEVER modify objects from the store. It's a read-only, local cache.
+	// You can use DeepCopy() to make a deep copy of original object and modify this copy
+	// Or create a copy manually for better performance
 	copy := db.DeepCopy()
 	copy.Status.State = state
 	copy.Status.Message = msg
-	// Until #38113 is merged, we must use Update instead of UpdateStatus to
-	// update the Status block of the resource. UpdateStatus will not
-	// allow changes to the Spec of the resource, which is ideal for ensuring
+	// UpdateStatus will not allow changes to the Spec of the resource, which is ideal for ensuring
 	// nothing other than resource status has been updated.
-	_, err := c.atlasclientset.AtlasdbV1alpha1().Databases(db.Namespace).Update(copy)
+	_, err := c.atlasclientset.AtlasdbV1alpha1().Databases(db.Namespace).UpdateStatus(copy)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("error updating status to '%s' for database '%s': %s", state, key, err))
 		return db, err

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -18,6 +18,8 @@ spec:
           properties:
             servicePort:
               type: integer
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -30,6 +32,8 @@ spec:
     kind: Database
     plural: databases
   scope: Namespaced
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -55,3 +59,5 @@ spec:
             version:
               type: integer
               minimum: 0
+  subresources:
+    status: {}

--- a/pkg/client/clientset/versioned/typed/db/v1alpha1/database.go
+++ b/pkg/client/clientset/versioned/typed/db/v1alpha1/database.go
@@ -37,6 +37,7 @@ type DatabasesGetter interface {
 type DatabaseInterface interface {
 	Create(*v1alpha1.Database) (*v1alpha1.Database, error)
 	Update(*v1alpha1.Database) (*v1alpha1.Database, error)
+	UpdateStatus(*v1alpha1.Database) (*v1alpha1.Database, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.Database, error)
@@ -114,6 +115,20 @@ func (c *databases) Update(database *v1alpha1.Database) (result *v1alpha1.Databa
 		Namespace(c.ns).
 		Resource("databases").
 		Name(database.Name).
+		Body(database).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+func (c *databases) UpdateStatus(database *v1alpha1.Database) (result *v1alpha1.Database, err error) {
+	result = &v1alpha1.Database{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("databases").
+		Name(database.Name).
+		SubResource("status").
 		Body(database).
 		Do().
 		Into(result)

--- a/pkg/client/clientset/versioned/typed/db/v1alpha1/databaseschema.go
+++ b/pkg/client/clientset/versioned/typed/db/v1alpha1/databaseschema.go
@@ -37,6 +37,7 @@ type DatabaseSchemasGetter interface {
 type DatabaseSchemaInterface interface {
 	Create(*v1alpha1.DatabaseSchema) (*v1alpha1.DatabaseSchema, error)
 	Update(*v1alpha1.DatabaseSchema) (*v1alpha1.DatabaseSchema, error)
+	UpdateStatus(*v1alpha1.DatabaseSchema) (*v1alpha1.DatabaseSchema, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.DatabaseSchema, error)
@@ -114,6 +115,20 @@ func (c *databaseSchemas) Update(databaseSchema *v1alpha1.DatabaseSchema) (resul
 		Namespace(c.ns).
 		Resource("databaseschemas").
 		Name(databaseSchema.Name).
+		Body(databaseSchema).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+func (c *databaseSchemas) UpdateStatus(databaseSchema *v1alpha1.DatabaseSchema) (result *v1alpha1.DatabaseSchema, err error) {
+	result = &v1alpha1.DatabaseSchema{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("databaseschemas").
+		Name(databaseSchema.Name).
+		SubResource("status").
 		Body(databaseSchema).
 		Do().
 		Into(result)

--- a/pkg/client/clientset/versioned/typed/db/v1alpha1/databaseserver.go
+++ b/pkg/client/clientset/versioned/typed/db/v1alpha1/databaseserver.go
@@ -37,6 +37,7 @@ type DatabaseServersGetter interface {
 type DatabaseServerInterface interface {
 	Create(*v1alpha1.DatabaseServer) (*v1alpha1.DatabaseServer, error)
 	Update(*v1alpha1.DatabaseServer) (*v1alpha1.DatabaseServer, error)
+	UpdateStatus(*v1alpha1.DatabaseServer) (*v1alpha1.DatabaseServer, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.DatabaseServer, error)
@@ -114,6 +115,20 @@ func (c *databaseServers) Update(databaseServer *v1alpha1.DatabaseServer) (resul
 		Namespace(c.ns).
 		Resource("databaseservers").
 		Name(databaseServer.Name).
+		Body(databaseServer).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+func (c *databaseServers) UpdateStatus(databaseServer *v1alpha1.DatabaseServer) (result *v1alpha1.DatabaseServer, err error) {
+	result = &v1alpha1.DatabaseServer{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("databaseservers").
+		Name(databaseServer.Name).
+		SubResource("status").
 		Body(databaseServer).
 		Do().
 		Into(result)


### PR DESCRIPTION
  - This change adds support for `Status` subresource in CRD's.
  - Minor refactoring
  - Required kubernetes version 1.10 or greater and CustomeSubResource field-gate
    enabled.